### PR TITLE
cabal: Add missing gio-unix dependency

### DIFF
--- a/bustle.cabal
+++ b/bustle.cabal
@@ -112,7 +112,8 @@ Executable bustle
     ghc-options: -threaded
   C-sources: c-sources/pcap-monitor.c
   cc-options: -fPIC -g
-  pkgconfig-depends: glib-2.0 >= 2.54
+  pkgconfig-depends: glib-2.0 >= 2.54,
+                     gio-unix-2.0
   Build-Depends: base >= 4 && < 5
                , bytestring
                , cairo


### PR DESCRIPTION
On Nix, the build fails with

```
c-sources/pcap-monitor.c:28:10: error:
     fatal error: gio/gunixinputstream.h: No such file or directory
     #include <gio/gunixinputstream.h>
              ^~~~~~~~~~~~~~~~~~~~~~~~
```

This commit fixes that.